### PR TITLE
appAppleId can be null before apple' review

### DIFF
--- a/src/response/HistoryResponse.php
+++ b/src/response/HistoryResponse.php
@@ -19,7 +19,7 @@ class HistoryResponse extends Response
     {
         parent::__construct($contents);
         $arr = json_decode($contents, true);
-        $this->appAppleId = $arr['appAppleId'];
+        $this->appAppleId = $arr['appAppleId'] ?? null;
         $this->bundleId = $arr['bundleId'];
         $this->environment = $arr['environment'];
         $this->hasMore = $arr['hasMore'];

--- a/src/response/StatusResponse.php
+++ b/src/response/StatusResponse.php
@@ -25,7 +25,7 @@ class StatusResponse extends Response
         if (!$arr) {
             return;
         }
-        $this->appAppleId = $arr['appAppleId'];
+        $this->appAppleId = $arr['appAppleId'] ?? null;
         $this->bundleId = $arr['bundleId'];
         $this->environment = $arr['environment'];
 


### PR DESCRIPTION
appAppleId is optional. If the app has not been submitted for review, the field is not included in the server response.